### PR TITLE
Update travis config to run against the latest four Go releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: go
 go:
-  - 1.8.x
-  - 1.7.x
-  - master
+  - "1.10"
+  - "1.9"
+  - "1.8"
+  - "1.7"
 matrix:
   allow_failures:
     - go: master


### PR DESCRIPTION
Quote the releases, since otherwise the YAML syntax for `1.10` will
be interpreted as a float, matching against Go 1.1.

Drop master, since it doesn't seem a useful reference point.