### PR TITLE
use Caller() to find the licenses.db file instead of GOPATH

### DIFF
--- a/file_system_resources.go
+++ b/file_system_resources.go
@@ -15,10 +15,12 @@
 package licenseclassifier
 
 import (
-	"go/build"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 const (
@@ -32,34 +34,35 @@ const (
 	ForbiddenLicenseArchive = "forbidden_licenses.db"
 )
 
-func findInGOPATH(rel string) (fullPath string, err error) {
-	for _, path := range filepath.SplitList(build.Default.GOPATH) {
-		fullPath := filepath.Join(path, rel)
-		if _, err := os.Stat(fullPath); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return "", err
-		}
-		return fullPath, nil
+// lcRoot computes the location of the licenses data in the licenseclassifier source tree based on the location of this file.
+func lcRoot() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to compute path of licenseclassifier source")
 	}
-	return "", nil
+	// this file must be in the root of the package, or the relative paths will be wrong.
+	return filepath.Join(filepath.Dir(filename), "licenses"), nil
 }
 
-// ReadLicenseFile locates and reads the license file.
+// ReadLicenseFile locates and reads the license archive file.  Absolute paths are used unmodified.  Relative paths are expected to be in the licenses directory of the licenseclassifier package.
 func ReadLicenseFile(filename string) ([]byte, error) {
-	archive, err := findInGOPATH(filepath.Join(LicenseDirectory, filename))
-	if err != nil || archive == "" {
-		return nil, err
+	if strings.HasPrefix(filename, "/") {
+		return ioutil.ReadFile(filename)
 	}
-	return ioutil.ReadFile(archive)
+
+	root, err := lcRoot()
+	if err != nil {
+		return nil, fmt.Errorf("error locating licenses directory: %v", err)
+	}
+	return ioutil.ReadFile(filepath.Join(root, filename))
 }
 
 // ReadLicenseDir reads directory containing the license files.
 func ReadLicenseDir() ([]os.FileInfo, error) {
-	filename, err := findInGOPATH(filepath.Join(LicenseDirectory, LicenseArchive))
-	if err != nil || filename == "" {
-		return nil, err
+	root, err := lcRoot()
+	if err != nil {
+		return nil, fmt.Errorf("error locating licenses directory: %v", err)
 	}
-	return ioutil.ReadDir(filepath.Dir(filename))
+
+	return ioutil.ReadDir(root)
 }


### PR DESCRIPTION
Instead of looking for the files relative to GOPATH, instead we look for
files relative to the directory file_system_resources.go is in, unless an
absolute path is specified.

This will work under traditional GOPATH and `go mod` scenarios.  It doesn't
help with binaries that are built and the source code moved or removed.