### PR TITLE
Updated archive options to take user-provided bytes or a function

### DIFF
--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -55,12 +55,12 @@ func ArchiveLicenses(licenses []string, w io.Writer) error {
 			str = n(str)
 		}
 
-		baseName := strings.TrimSuffix(license, ext)
+		baseName := strings.TrimSuffix(filepath.Base(license), ext)
 
 		// Serialize the normalized license text.
 		log.Printf("Serializing %q", baseName)
 		hdr := &tar.Header{
-			Name: license,
+			Name: filepath.Base(license),
 			Mode: 0644,
 			Size: int64(len(str)),
 		}


### PR DESCRIPTION
This allows library users the flexibility to load their DB from an alternate location, including the network or an embedded array, if necessary.

Also fixed a bug whereby archive serialization would store the whole path. Now, the archive properly stores only the ID instead of the entire path to the ID. This happened when an absolute path was used for the directory, which is useful if you're using a DB in an alternate location.