### PR TITLE
identity_license: prevent send on closed channel

### DIFF
--- a/tools/identify_license/backend/backend.go
+++ b/tools/identify_license/backend/backend.go
@@ -78,8 +78,8 @@ func (b *ClassifierBackend) ClassifyLicenses(filenames []string, headers bool) (
 	var wg sync.WaitGroup
 	analyze := func(filename string) {
 		defer func() {
-			wg.Done()
 			task <- true
+			wg.Done()
 		}()
 		if err := b.classifyLicense(filename, headers); err != nil {
 			errs <- err


### PR DESCRIPTION
I've occasionally been seeing the following panic when running `identity_license`:

```
panic: send on closed channel

goroutine 51 [running]:
github.com/google/licenseclassifier/tools/identify_license/backend.(*ClassifierBackend).ClassifyLicenses.func1.1(0xc0043a1910, 0xc003466900)
        licenseclassifier/tools/identify_license/backend/backend.go:82 +0x4e
github.com/google/licenseclassifier/tools/identify_license/backend.(*ClassifierBackend).ClassifyLicenses.func1(0x7ffeefbff9b9, 0x13)
        licenseclassifier/tools/identify_license/backend/backend.go:87 +0xb8
created by github.com/google/licenseclassifier/tools/identify_license/backend.(*ClassifierBackend).ClassifyLicenses
        licenseclassifier/tools/identify_license/backend/backend.go:92 +0x1ea
```

The commit message explains this issue and the fix:

```
The analyze function calls Done on the waitgroup and then opens up
a new slot by writing into the `task` channel. If this is the last
goroutine running, this can cause an issue: there is a goroutine
running that is waiting for the waitgroup to yield. After this it
closes the `task` channel. If it gets closed before the
`analyze` goroutine manages to send true into the channel, a panic
can occur.

The channel send and `wg.Done()` call could be re-ordeded, but also
there is no strict need to close the channel in this instance, as
there is no receiver for it after this point.
```

Happy to adjust to something else if there are different opinions on how to deal with this.