### PR TITLE
Add dummy.go to licenses dir

### DIFF
--- a/licenses/dummy.go
+++ b/licenses/dummy.go
@@ -1,0 +1,5 @@
+// +build tools
+
+package licenses
+
+// Placeholder, allows others to pull in the licenses.db file via go.mod.


### PR DESCRIPTION
This allows users of https://github.com/google/go-licenses to run the tool in a go
module compliant way by depending on this package, and running the tool. Without this
that invariably fails with 'licenses.db cannot be found'.

With this, users can add

github.com/google/go-licenses
and
github.com/google/licenseclassifier/licenses

to their hack/tools.go file, and then the run of the license classifier is hermetic (uses only the versions known by go modules, which prevents weird inconsistencies due to mismatched tool versions).
