### PR TITLE
Remove redundant if condition in header() function

### DIFF
--- a/v2/tokenizer.go
+++ b/v2/tokenizer.go
@@ -296,7 +296,7 @@ func header(tok *token) bool {
 			// Sometimes an internal reference like "(ii)" from NPL-1.02.txt
 			// ends up at the beginning of a line. In that case, it's
 			// not actually a header.
-			if e == ')' && !strings.HasSuffix(tok.Previous, "(") {
+			if !strings.HasSuffix(tok.Previous, "(") {
 				return true
 			}
 		}


### PR DESCRIPTION
This PR removes a redundant condition in a if statement.
In this [line](https://github.com/google/licenseclassifier/blob/8ad7a259af99b034052de80dea35daef2b478c2a/v2/tokenizer.go#L299) the condition to check `e==')'` is redundant as we are already checking in the above case statement and the condition 
`if e!=')'` and then returning. So the condition `e==')'` should not make any difference.