### PR TITLE
Make the dummy dep on licenses dir stronger

### DIFF
--- a/file_system_resources.go
+++ b/file_system_resources.go
@@ -21,7 +21,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/google/licenseclassifier/licenses"
 )
+
+// forceDepOnLicenses is used to force a package dependency on the licenses
+// dir, which includes the LicenseArchive and ForbiddenLicenseArchive files.
+type forceDepOnLicenses licenses.Dummy
 
 const (
 	// LicenseDirectory is the directory where the prototype licenses are kept.

--- a/licenses/dummy.go
+++ b/licenses/dummy.go
@@ -1,5 +1,7 @@
-// +build tools
-
+// Package dummy is a placeholder. This allows consumers of licenseclassifier
+// to use Go modules and vendoring and still find in the licenses.db file.
 package licenses
 
-// Placeholder, allows others to pull in the licenses.db file via go.mod.
+// Dummy is a pointless type which is used to satisfy Go's dependency-tracking
+// to include this directory.
+type Dummy struct{}


### PR DESCRIPTION
Without an actual code-level dependency, `go mod vendor` will elide the
licenses directory, which is where the actual DB files are stored.
Without those, it's not very useful to vendor this lib.

@wcn3