### PR TITLE
Fix typo in [v2/classifier_test.go]

### DIFF
--- a/v2/classifier_test.go
+++ b/v2/classifier_test.go
@@ -124,7 +124,7 @@ func TestContainsAndOverlaps(t *testing.T) {
 			overlaps: false,
 		},
 		{
-			name: "overlap at end",
+			name: "overlap at start",
 			a: &Match{
 				StartLine: 4,
 				EndLine:   10,


### PR DESCRIPTION
https://github.com/google/licenseclassifier/blob/bb04aff29e72e636ba260ec61150c6e15f111d7e/v2/classifier_test.go#L127
I changed it to   `name: "overlap at start"`
Fixes #35 