### PR TITLE
Embed the license data into the library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: go
 go:
-  - "1.13"
-  - "1.14"
-  - "1.15"
+  - "1.16"
 matrix:
   allow_failures:
     - go: master

--- a/file_system_resources.go
+++ b/file_system_resources.go
@@ -15,23 +15,10 @@
 package licenseclassifier
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
-
 	"github.com/google/licenseclassifier/licenses"
 )
 
-// forceDepOnLicenses is used to force a package dependency on the licenses
-// dir, which includes the LicenseArchive and ForbiddenLicenseArchive files.
-type forceDepOnLicenses licenses.Dummy
-
 const (
-	// LicenseDirectory is the directory where the prototype licenses are kept.
-	LicenseDirectory = "src/github.com/google/licenseclassifier/licenses"
 	// LicenseArchive is the name of the archive containing preprocessed
 	// license texts.
 	LicenseArchive = "licenses.db"
@@ -40,35 +27,8 @@ const (
 	ForbiddenLicenseArchive = "forbidden_licenses.db"
 )
 
-// lcRoot computes the location of the licenses data in the licenseclassifier source tree based on the location of this file.
-func lcRoot() (string, error) {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", fmt.Errorf("unable to compute path of licenseclassifier source")
-	}
-	// this file must be in the root of the package, or the relative paths will be wrong.
-	return filepath.Join(filepath.Dir(filename), "licenses"), nil
-}
-
 // ReadLicenseFile locates and reads the license archive file.  Absolute paths are used unmodified.  Relative paths are expected to be in the licenses directory of the licenseclassifier package.
-func ReadLicenseFile(filename string) ([]byte, error) {
-	if strings.HasPrefix(filename, "/") {
-		return ioutil.ReadFile(filename)
-	}
-
-	root, err := lcRoot()
-	if err != nil {
-		return nil, fmt.Errorf("error locating licenses directory: %v", err)
-	}
-	return ioutil.ReadFile(filepath.Join(root, filename))
-}
+var ReadLicenseFile = licenses.ReadLicenseFile
 
 // ReadLicenseDir reads directory containing the license files.
-func ReadLicenseDir() ([]os.FileInfo, error) {
-	root, err := lcRoot()
-	if err != nil {
-		return nil, fmt.Errorf("error locating licenses directory: %v", err)
-	}
-
-	return ioutil.ReadDir(root)
-}
+var ReadLicenseDir = licenses.ReadLicenseDir

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/licenseclassifier
 
-go 1.11
+go 1.16
 
 require (
 	github.com/google/go-cmp v0.2.0

--- a/licenses/dummy.go
+++ b/licenses/dummy.go
@@ -1,7 +1,0 @@
-// Package dummy is a placeholder. This allows consumers of licenseclassifier
-// to use Go modules and vendoring and still find in the licenses.db file.
-package licenses
-
-// Dummy is a pointless type which is used to satisfy Go's dependency-tracking
-// to include this directory.
-type Dummy struct{}

--- a/licenses/embed.go
+++ b/licenses/embed.go
@@ -1,0 +1,19 @@
+package licenses
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed *.db *.txt
+var licenseFS embed.FS
+
+// ReadLicenseFile locates and reads the license archive file.  Absolute paths are used unmodified.  Relative paths are expected to be in the licenses directory of the licenseclassifier package.
+func ReadLicenseFile(filename string) ([]byte, error) {
+	return licenseFS.ReadFile(filename)
+}
+
+// ReadLicenseDir reads directory containing the license files.
+func ReadLicenseDir() ([]fs.DirEntry, error) {
+	return licenseFS.ReadDir(".")
+}


### PR DESCRIPTION
Thus we no longer need the modcache present for the library to work properly