### PR TITLE
Update embed.go

### DIFF
--- a/licenses/embed.go
+++ b/licenses/embed.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-//go:embed *.db *.txt
+// go:embed *.db *.txt
 var licenseFS embed.FS
 
 // ReadLicenseFile locates and reads the license archive file.  Absolute paths are used unmodified.  Relative paths are expected to be in the licenses directory of the licenseclassifier package.


### PR DESCRIPTION
Fixed comment to work when using go get command

Currently when using go get -u github.com/google/licenseclassifier/... I get the following error:

`/opt/gocode/pkg/mod/github.com/google/licenseclassifier@v0.0.0-20220712234305-c913e304a153/licenses/embed.go:8:12: pattern *.db: no matching files found
/opt/gocode/pkg/mod/github.com/google/licenseclassifier@v0.0.0-20220712234305-c913e304a153/licenses/embed.go:8:12: pattern *.db: no matching files found
`

But when I changed ( locally ) the attached change it seems to work.

Env: Ubuntu 16 with Go 16.15 installed 