### PR TITLE
fix: Embed split asset paths on forward-slash

### DIFF
--- a/v2/assets/embed.go
+++ b/v2/assets/embed.go
@@ -2,9 +2,7 @@ package assets
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
-	"os"
 	"strings"
 
 	classifier "github.com/google/licenseclassifier/v2"
@@ -30,7 +28,7 @@ func DefaultClassifier() (*classifier.Classifier, error) {
 		if err != nil {
 			return err
 		}
-		splits := strings.Split(path, fmt.Sprintf("%c", os.PathSeparator))
+		splits := strings.Split(path, "/")
 		category, name, variant := splits[0], splits[1], splits[2]
 		c.AddContent(category, name, variant, b)
 		return nil


### PR DESCRIPTION
The split for v2 assets shouldn't be on platform specific path separator, it will always be a `/`

Resolvese #49

Signed-off-by: Owen Rumney <owen@owenrumney.co.uk>
