### PR TITLE
nit: correct embed comment for the licence db

### DIFF
--- a/licenses/embed.go
+++ b/licenses/embed.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-// go:embed *.db *.txt
+//go:embed *.db *.txt
 var licenseFS embed.FS
 
 // ReadLicenseFile locates and reads the license archive file.  Absolute paths are used unmodified.  Relative paths are expected to be in the licenses directory of the licenseclassifier package.


### PR DESCRIPTION
This is the correct format for the embed directives. It seems that `go build` will allow this format, but IDEs like intellij won't highlight this correctly, and things like [build.Import](https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/go/build/build.go;l=553) (which are used by linters and other build systems to analyse go code) won't pick up these embed patterns.