### PR TITLE
Add NewDefaultClassifier to create a Classifier with default settings

### DIFF
--- a/v2/classifier.go
+++ b/v2/classifier.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -211,6 +212,14 @@ func NewClassifier(threshold float64) *Classifier {
 		q:         computeQ(threshold),
 	}
 	return classifier
+}
+
+var defaultThreshold = .8
+var baseLicenses = "assets"
+
+func NewDefaultClassifier() (*Classifier, error) {
+	c := NewClassifier(defaultThreshold)
+	return c, c.LoadLicenses(path.Join(baseLicenses))
 }
 
 // Normalize takes input content and applies the following transforms to aid in

--- a/v2/classifier_test.go
+++ b/v2/classifier_test.go
@@ -36,14 +36,6 @@ type scenario struct {
 	data     []byte
 }
 
-var defaultThreshold = .8
-var baseLicenses = "assets"
-
-func classifier() (*Classifier, error) {
-	c := NewClassifier(defaultThreshold)
-	return c, c.LoadLicenses(path.Join(baseLicenses))
-}
-
 func getScenarioFilenames() ([]string, error) {
 	scenarios := "scenarios"
 	var files []string
@@ -62,7 +54,7 @@ func getScenarioFilenames() ([]string, error) {
 }
 
 func TestMatchScenarios(t *testing.T) {
-	c, err := classifier()
+	c, err := NewDefaultClassifier()
 	if err != nil {
 		t.Fatalf("couldn't instantiate standard test classifier: %v", err)
 	}
@@ -214,7 +206,7 @@ func TestLicName(t *testing.T) {
 
 func TestMatchFrom(t *testing.T) {
 	tr := iotest.TimeoutReader(strings.NewReader("some data"))
-	c, err := classifier()
+	c, err := NewDefaultClassifier()
 	if err != nil {
 		t.Fatalf("couldn't instantiate standard Google classifier: %v", err)
 	}
@@ -350,7 +342,7 @@ ball football`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			c, err := classifier()
+			c, err := NewDefaultClassifier()
 			if err != nil {
 				t.Fatalf("couldn't instantiate standard Google classifier: %v", err)
 			}


### PR DESCRIPTION
I moved the function that creates a Classifier object with default setting from `v2/classifier_test.go` to `v2/classifier.go`. This could help developers not to look for the relative path from the place where they want to call `LoadLicenses` to `vendor/github.com/google/licenseclassifier/v2/assets` if they are using `go mod vendor`.