### PR TITLE
Add "FORBIDDEN" to LicenseTypes and byExceptionOnlyType to LicenseType()

### DIFF
--- a/license_type.go
+++ b/license_type.go
@@ -371,6 +371,7 @@ var (
 		"permissive",
 		"unencumbered",
 		"by_exception_only",
+		"FORBIDDEN",
 	)
 )
 
@@ -387,6 +388,8 @@ func LicenseType(name string) string {
 		return "permissive"
 	case unencumberedType.Contains(name):
 		return "unencumbered"
+	case byExceptionOnlyType.Contains(name):
+		return "by_exception_only"
 	case forbiddenType.Contains(name):
 		return "FORBIDDEN"
 	}


### PR DESCRIPTION
Previously the `StringSet` `byExceptionOnlyType` was defined but not used. This change adds it to the function `LicenseType` to get the type string "by_exception_only" when applicable.