### PR TITLE
Make the tool usable without modification.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+licenses/licenses.db

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ A "confidence level" is associated with each result indicating how close the
 match was. A confidence level of `1.0` indicates an exact match, while a
 confidence level of `0.0` indicates that no license was able to match the text.
 
+## Usage
+
+### One-time setup
+
+Use the `license_serializer` tool to regenerate the `licenses.db` archive.
+The archive contains preprocessed license texts for quicker comparisons against
+unknown texts.
+
+```shell
+$ go run tools/license_serializer/license_serializer.go -output licenses
+```
+
+### Identifying licenses
+
+Use the `identify_license` command line tool to identify the license(s)
+within a file.
+
+```shell
+$ go run tools/identify_license/identify_license.go /path/to/LICENSE
+LICENSE: GPL-2.0 (confidence: 1, offset: 0, extent: 14794)
+LICENSE: LGPL-2.1 (confidence: 1, offset: 18366, extent: 23829)
+LICENSE: MIT (confidence: 1, offset: 17255, extent: 1059)
+```
+
 ## Adding a new license
 
 Adding a new license is straight-forward:
@@ -36,30 +60,6 @@ Adding a new license is straight-forward:
 
 4.  Create and run appropriate tests to verify that the license is indeed
     present.
-
-## Tools
-
-### Identify license
-
-`identify_license` is a command line tool that can identify the license(s)
-within a file.
-
-```shell
-$ identify_license LICENSE
-LICENSE: GPL-2.0 (confidence: 1, offset: 0, extent: 14794)
-LICENSE: LGPL-2.1 (confidence: 1, offset: 18366, extent: 23829)
-LICENSE: MIT (confidence: 1, offset: 17255, extent: 1059)
-```
-
-### License serializer
-
-The `license_serializer` tool regenerates the `licenses.db` archive. The archive
-contains preprocessed license texts for quicker comparisons against unknown
-texts.
-
-```shell
-$ license_serializer -output licenseclassifier/licenses
-```
 
 ----
 This is not an official Google product (experimental or otherwise), it is just


### PR DESCRIPTION
1. When trying to generate licenses.db from a fresh code checkout, the embed directive "//go:embed *.db *.txt" fails because there are no files matching *.db. As a workaround, add an empty file "empty.db" so there is a match.

2. licenses.db should not be checked in, so add it to a new .gitignore file.

3. Reorganize README.db with clearer and more prominent instructions on how to use the tool.