### PR TITLE
Adding the Hashicorp variant of the Business Source License 1.1

### DIFF
--- a/v2/assets/License/Business-Source-License-1.1/hashicorp.txt
+++ b/v2/assets/License/Business-Source-License-1.1/hashicorp.txt
@@ -1,0 +1,42 @@
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.


### PR DESCRIPTION
Fixes: #67 

Hashicorp relicensed their product offering to the Business Source License 1.1

https://github.com/search?q=org%3Ahashicorp+%22Business+Source+License+1.1%22+language%3AText&type=code&l=Text

The LICENSE files installed in the repositories have a Hashicorp specific preamble, for instance:\

https://github.com/hashicorp/terraform/blob/ec0ecca1a6eef4bd90138de064b9e54b668622ac/LICENSE#L4-L47

I added a variant to the Business Source License assets folder matching the Hashicorp style LICENSE files starting from line 51.

https://github.com/hashicorp/terraform/blob/ec0ecca1a6eef4bd90138de064b9e54b668622ac/LICENSE#L4-L47

With this variant in place, the licenses are properly matched:

```
$ cd v2
$ wget https://raw.githubusercontent.com/hashicorp/terraform/refs/heads/main/LICENSE -O LICENSE-tf.txt
$ go run tools/identify_license/identify_license.go LICENSE-tf.txt
2025/03/11 12:46:39 Classifying license(s): /Users/ringods/Projects/pulumi/licenseclassifier/v2/LICENSE-tf.txt
2025/03/11 12:46:39 Finished Classifying License "/Users/ringods/Projects/pulumi/licenseclassifier/v2/LICENSE-tf.txt": 4.395ms
/Users/ringods/Projects/pulumi/licenseclassifier/v2/LICENSE-tf.txt Business-Source-License-1.1 (variant: hashicorp.txt, confidence: 1, start: 51, end: 92)
$ wget https://raw.githubusercontent.com/hashicorp/vault/refs/heads/main/LICENSE -O LICENSE-vault.txt
$ go run tools/identify_license/identify_license.go LICENSE-vault.txt
2025/03/11 12:47:36 Classifying license(s): /Users/ringods/Projects/pulumi/licenseclassifier/v2/LICENSE-vault.txt
2025/03/11 12:47:36 Finished Classifying License "/Users/ringods/Projects/pulumi/licenseclassifier/v2/LICENSE-vault.txt": 4.367292ms
/Users/ringods/Projects/pulumi/licenseclassifier/v2/LICENSE-vault.txt Business-Source-License-1.1 (variant: hashicorp.txt, confidence: 1, start: 51, end: 92)
```

How can I add & run tests from `v2/scenarios`?