### PR TITLE
feat(workflows): checkout google/licenseclassifier in classify.yml

### DIFF
--- a/.github/workflows/classify.yml
+++ b/.github/workflows/classify.yml
@@ -19,6 +19,8 @@ jobs:
       license_name: ${{ steps.classify.outputs.license_name }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        repository: google/licenseclassifier
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
This change modifies the `classify` workflow to explicitly check out the `google/licenseclassifier` repository. This ensures that the correct version of the license classifier tool is used in the workflow, regardless of where the workflow is triggered from.